### PR TITLE
Add registry to allow dynamic connection of tasks

### DIFF
--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 defmt = "0.3"
- mycelium-bitfield = { git = "https://github.com/hawkw/mycelium.git" }
+mycelium-bitfield = { git = "https://github.com/hawkw/mycelium.git" }

--- a/abi/src/caps.rs
+++ b/abi/src/caps.rs
@@ -15,14 +15,15 @@ pub struct Endpoint {
     pub disposable: bool,
 }
 
-#[derive(Clone, defmt::Format)]
-#[repr(C)]
+pub type PortId = [u8; 16];
 
+#[derive(Clone, Copy, defmt::Format)]
+#[repr(C)]
 pub struct Listen {
-    pub port: [u8; 10],
+    pub port: PortId,
 }
-#[derive(Clone, defmt::Format)]
+#[derive(Clone, Copy, defmt::Format)]
 #[repr(C)]
 pub struct Connect {
-    pub port: [u8; 10],
+    pub port: PortId,
 }

--- a/abi/src/caps.rs
+++ b/abi/src/caps.rs
@@ -1,0 +1,28 @@
+#[derive(Clone, defmt::Format)]
+#[repr(C)]
+pub enum Cap {
+    Endpoint(Endpoint),
+    Listen(Listen),
+    Connect(Connect),
+    Notification,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, defmt::Format)]
+pub struct Endpoint {
+    pub tcb_ref: super::ThreadRef,
+    pub addr: usize,
+    pub disposable: bool,
+}
+
+#[derive(Clone, defmt::Format)]
+#[repr(C)]
+
+pub struct Listen {
+    pub port: [u8; 10],
+}
+#[derive(Clone, defmt::Format)]
+#[repr(C)]
+pub struct Connect {
+    pub port: [u8; 10],
+}

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -18,12 +18,14 @@ mycelium_bitfield::bitfield! {
 #[derive(Debug)]
 #[repr(u8)]
 pub enum SyscallFn {
-    Send = 0b0001,
-    Call = 0b0010,
-    Recv = 0b0011,
-    Log = 0b0101,
-    Caps = 0b0111,
-    Panik = 0b0110,
+    Send = 0x0,
+    Call = 0x1,
+    Recv = 0x2,
+    Log = 0x3,
+    Caps = 0x4,
+    Panik = 0x5,
+    Connect = 0x6,
+    Listen = 0x7,
 }
 
 impl FromBits<u32> for SyscallFn {
@@ -38,6 +40,8 @@ impl FromBits<u32> for SyscallFn {
             bits if bits == Self::Log as u8 => Ok(Self::Log),
             bits if bits == Self::Caps as u8 => Ok(Self::Caps),
             bits if bits == Self::Panik as u8 => Ok(Self::Panik),
+            bits if bits == Self::Connect as u8 => Ok(Self::Connect),
+            bits if bits == Self::Listen as u8 => Ok(Self::Listen),
             _ => Err("expected valid syscall fn identifier"),
         }
     }
@@ -143,6 +147,7 @@ pub enum Error {
     BadAccess,
     BufferOverflow,
     PortNotOpen,
+    InvalidCap,
     Unknown(u8),
 }
 
@@ -153,6 +158,7 @@ impl From<u8> for Error {
             2 => Error::BadAccess,
             3 => Error::BufferOverflow,
             4 => Error::PortNotOpen,
+            5 => Error::InvalidCap,
             code => Error::Unknown(code),
         }
     }
@@ -165,6 +171,7 @@ impl From<Error> for u8 {
             Error::BadAccess => 2,
             Error::BufferOverflow => 3,
             Error::PortNotOpen => 4,
+            Error::InvalidCap => 5,
             Error::Unknown(code) => code,
         }
     }

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -97,7 +97,6 @@ mycelium_bitfield::bitfield! {
     #[derive( Eq, PartialEq)]
     pub struct SyscallReturn<u64> {
         pub const SYSCALL_TYPE: SyscallReturnType;
-        pub const SYSCALL_CAP = 8;
         pub const SYSCALL_LEN = 22;
         pub const SYSCALL_PTR = 32;
     }
@@ -172,7 +171,9 @@ impl From<Error> for u8 {
 }
 
 #[derive(Clone, Copy, defmt::Format)]
+#[repr(C)]
 pub struct CapRef(pub usize);
+
 impl Deref for CapRef {
     type Target = usize;
 

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+mod caps;
+pub use caps::*;
 use core::ops::Deref;
 
 use defmt::Format;
@@ -141,6 +143,7 @@ pub enum Error {
     ReturnTypeMismatch,
     BadAccess,
     BufferOverflow,
+    PortNotOpen,
     Unknown(u8),
 }
 
@@ -150,6 +153,7 @@ impl From<u8> for Error {
             1 => Error::ReturnTypeMismatch,
             2 => Error::BadAccess,
             3 => Error::BufferOverflow,
+            4 => Error::PortNotOpen,
             code => Error::Unknown(code),
         }
     }
@@ -161,6 +165,7 @@ impl From<Error> for u8 {
             Error::ReturnTypeMismatch => 1,
             Error::BadAccess => 2,
             Error::BufferOverflow => 3,
+            Error::PortNotOpen => 4,
             Error::Unknown(code) => code,
         }
     }
@@ -180,21 +185,6 @@ impl From<usize> for CapRef {
     fn from(i: usize) -> Self {
         CapRef(i)
     }
-}
-
-#[derive(Clone, defmt::Format)]
-#[repr(C)]
-pub enum Cap {
-    Endpoint(Endpoint),
-    Notification,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, defmt::Format)]
-pub struct Endpoint {
-    pub tcb_ref: ThreadRef,
-    pub addr: usize,
-    pub disposable: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, defmt::Format)]

--- a/examples/bar/src/main.rs
+++ b/examples/bar/src/main.rs
@@ -11,7 +11,6 @@ pub fn main() -> ! {
     let caps = userspace::caps().unwrap();
     println!("{:?}", &*caps);
     let mut a: u32 = 20;
-    userspace::panik();
     loop {
         a += 1;
         if a % 50000 == 0 {

--- a/examples/bar/src/main.rs
+++ b/examples/bar/src/main.rs
@@ -10,6 +10,8 @@ use userspace::CapExt;
 pub fn main() -> ! {
     let caps = userspace::caps().unwrap();
     println!("{:?}", &*caps);
+    let endpoint = caps[0].cap_ref.connect().unwrap();
+    println!("connected: {:?}", endpoint);
     let mut a: u32 = 20;
     loop {
         a += 1;
@@ -18,7 +20,7 @@ pub fn main() -> ! {
             buf[0..4].copy_from_slice(&a.to_be_bytes());
             info!("send {:?}", buf);
             let mut resp_buf = [0; 10];
-            let resp = caps[0].cap_ref.call(&mut buf, &mut resp_buf);
+            let resp = endpoint.call(&mut buf, &mut resp_buf);
             info!("resp {:?}, buf: {:?}", resp, resp_buf);
         }
     }

--- a/examples/foo/src/main.rs
+++ b/examples/foo/src/main.rs
@@ -9,6 +9,8 @@ use userspace::CapExt;
 pub fn main() -> ! {
     let caps = userspace::caps().unwrap();
     defmt::println!("{:?}", &*caps);
+    caps[0].cap_ref.listen().unwrap();
+    defmt::println!("listen");
     let mut buf = [0u8; 10];
     loop {
         match userspace::recv(0, &mut buf) {

--- a/examples/idle/src/main.rs
+++ b/examples/idle/src/main.rs
@@ -11,7 +11,7 @@ pub fn main() -> ! {
     let mut a: u32 = 20;
     loop {
         a += 1;
-        if a % 500 == 0 {
+        if a % 50000 == 0 {
             info!("idle")
         }
     }

--- a/examples/stm32l5/.cargo/config.toml
+++ b/examples/stm32l5/.cargo/config.toml
@@ -22,3 +22,7 @@ rustflags = [
 # target = "thumbv8m.base-none-eabi"   # Cortex-M23
 # target = "thumbv8m.main-none-eabi"   # Cortex-M33 (no FPU)
 target = "thumbv8m.main-none-eabihf" # Cortex-M33 (with FPU)
+
+[profile.dev]
+opt-level = "z"
+lto = true

--- a/examples/stm32l5/.cargo/config.toml
+++ b/examples/stm32l5/.cargo/config.toml
@@ -24,5 +24,5 @@ rustflags = [
 target = "thumbv8m.main-none-eabihf" # Cortex-M33 (with FPU)
 
 [profile.dev]
-opt-level = "z"
-lto = true
+#opt-level = "z"
+#lto = true

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -6,8 +6,8 @@ name = "stm32l5"
 version = "0.1.0"
 
 [dependencies]
-# alloc-cortex-m = { git = "https://github.com/sphw/alloc-cortex-m.git", branch = "version-bumps" }
- alloc-cortex-m = { path = "../../../alloc-cortex-m" }
+alloc-cortex-m = { git = "https://github.com/sphw/alloc-cortex-m.git", branch = "version-bumps" }
+# alloc-cortex-m = { path = "../../../alloc-cortex-m" }
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 kernel = { path = "../../kernel" }

--- a/examples/stm32l5/app.toml
+++ b/examples/stm32l5/app.toml
@@ -10,7 +10,8 @@ chip = "STM32L562QEIxQ"
 crate_path = "./"
 ram_size   = 0x20000
 stack_size = 0x00004
-flash_size = 0x30000
+#flash_size = 0x9000 # min size
+flash_size = 0x10000
 
 [[tasks]]
 name = "idle"

--- a/examples/stm32l5/app.toml
+++ b/examples/stm32l5/app.toml
@@ -11,7 +11,7 @@ crate_path = "./"
 ram_size   = 0x20000
 stack_size = 0x00004
 #flash_size = 0x9000 # min size
-flash_size = 0x10000
+flash_size = 0x20000
 
 [[tasks]]
 name = "idle"

--- a/examples/stm32l5/src/main.rs
+++ b/examples/stm32l5/src/main.rs
@@ -25,8 +25,20 @@ fn main() -> ! {
     }
     let mut kernel = kernel::KernelBuilder::new(task_table::TASKS);
     let _idle = kernel.idle_thread(task_table::IDLE);
-    let foo = kernel.thread(task_table::FOO.priority(7).budget(2).cooldown(5));
-    let bar = kernel.thread(task_table::BAR.priority(7).budget(2).cooldown(5));
+    let foo = kernel.thread(
+        task_table::FOO
+            .priority(7)
+            .budget(2)
+            .cooldown(5)
+            .listen(*b"0123456789abcdef"),
+    );
+    let bar = kernel.thread(
+        task_table::BAR
+            .priority(7)
+            .budget(2)
+            .cooldown(5)
+            .connect(*b"0123456789abcdef"),
+    );
     kernel.endpoint(bar, foo, 0);
     info!("booting");
     kernel.start()

--- a/kernel/src/arch/dummy.rs
+++ b/kernel/src/arch/dummy.rs
@@ -1,12 +1,13 @@
+use crate::task::Task;
 use crate::task_ptr::{TaskPtr, TaskPtrMut};
-use crate::{Task, TCB};
+use crate::tcb::Tcb;
 
-pub(crate) fn start_root_task(_task: &Task, _tcb: &TCB) -> ! {
+pub(crate) fn start_root_task(_task: &Task, _tcb: &Tcb) -> ! {
     loop {
         std::thread::sleep(std::time::Duration::from_secs(100));
     }
 }
-pub(crate) fn init_tcb_stack(_task: &Task, _tcb: &mut TCB) {}
+pub(crate) fn init_tcb_stack(_task: &Task, _tcb: &mut Tcb) {}
 
 pub(crate) fn init_kernel<'k, 't>(tasks: &'t [crate::TaskDesc]) -> &'k mut crate::Kernel {
     let _ = crate::Kernel::from_tasks(tasks).unwrap();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -15,8 +15,12 @@ mod arch;
 mod builder;
 mod defmt_log;
 mod regions;
+mod registry;
 mod space;
 mod task_ptr;
+mod tcb;
+
+use tcb::*;
 
 pub use builder::*;
 #[cfg(test)]
@@ -641,141 +645,6 @@ pub enum KernelError {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct TaskRef(pub usize);
-
-#[repr(C)]
-pub(crate) struct Tcb {
-    saved_state: arch::SavedThreadState,
-    task: TaskRef, // Maybe use RC for this
-    req_queue: List<IPCMsg>,
-    state: ThreadState,
-    priority: usize,
-    budget: usize,
-    cooldown: usize,
-    capabilities: List<CapEntry>,
-    stack_pointer: usize,
-    entrypoint: usize,
-    epoch: usize,
-}
-
-impl Tcb {
-    pub fn new(
-        task: TaskRef,
-        stack_pointer: usize,
-        priority: usize,
-        budget: usize,
-        cooldown: usize,
-        entrypoint: usize,
-        epoch: usize,
-    ) -> Self {
-        Self {
-            task,
-            //_pad: 0,
-            req_queue: List::new(),
-            //reply_queue: List::new(),
-            state: ThreadState::Ready,
-            priority,
-            budget,
-            cooldown,
-            capabilities: List::new(),
-            stack_pointer,
-            entrypoint,
-            saved_state: Default::default(),
-            epoch,
-        }
-    }
-
-    #[inline]
-    fn cap_entry(&self, cap_ref: CapRef) -> Result<&CapEntry, KernelError> {
-        for c in self.capabilities.iter() {
-            let c_addr = (c as *const CapEntry).addr();
-            if c_addr == *cap_ref {
-                return Ok(c);
-            }
-        }
-        Err(KernelError::InvalidCapRef)
-    }
-
-    #[allow(dead_code)]
-    fn capability(&self, cap_ref: CapRef) -> Result<&Cap, KernelError> {
-        self.cap_entry(cap_ref).map(|e| &e.cap)
-    }
-
-    fn endpoint(&mut self, cap_ref: CapRef) -> Result<Endpoint, KernelError> {
-        let dest_cap = self.cap_entry(cap_ref)?;
-        let endpoint = if let Cap::Endpoint(endpoint) = dest_cap.cap {
-            endpoint
-        } else {
-            return Err(KernelError::WrongCapabilityType);
-        };
-        if endpoint.disposable {
-            // Safety: this function is marked as unsafe, because the user must guarentee that
-            // the item is in the list. dest_cap comes from self.capabilities, so this is safe
-            unsafe {
-                self.capabilities.remove(dest_cap.into());
-            }
-        }
-        Ok(endpoint)
-    }
-
-    pub fn add_cap(&mut self, cap: Cap) {
-        self.capabilities.push_back(Box::pin(CapEntry {
-            _links: Links::default(),
-            cap,
-        }));
-    }
-
-    fn recv(
-        &mut self,
-        task: &Task,
-        mask: usize,
-        out_buf: TaskPtrMut<'_, [u8]>,
-        recv_resp: TaskPtrMut<'_, MaybeUninit<RecvResp>>,
-    ) -> Result<bool, KernelError> {
-        let mut cursor = self.req_queue.cursor_front_mut();
-        cursor.move_prev();
-        let mut found = false;
-        while let Some(msg) = {
-            cursor.move_next();
-            cursor.current()
-        } {
-            if msg.addr & mask == mask {
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            return Ok(false);
-        }
-        let msg = cursor.remove_current().unwrap(); // found will only ever be set when there is a msg
-        let out_buf = task
-            .validate_mut_ptr(out_buf)
-            .ok_or(KernelError::InvalidTaskPtr)?;
-        let inner = &msg.inner.as_ref().unwrap();
-        if out_buf.len() != inner.body.len() {
-            self.saved_state
-                .set_syscall_return(abi::Error::ReturnTypeMismatch.into());
-            return Ok(true);
-        }
-        out_buf.copy_from_slice(&inner.body);
-        self.saved_state.set_syscall_return(
-            SyscallReturn::new().with(SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
-        );
-        let recv_resp = task
-            .validate_mut_ptr(recv_resp)
-            .ok_or(KernelError::InvalidTaskPtr)?; // TODO: make syscall return
-        let recv_resp = recv_resp.write(RecvResp {
-            cap: None,
-            inner: abi::RecvRespInner::Copy(inner.body.len()),
-        });
-        if let Some(reply) = inner.reply_endpoint {
-            self.add_cap(Cap::Endpoint(reply));
-            let cap_ptr = &*self.capabilities.back().unwrap() as *const CapEntry;
-            recv_resp.cap = Some(CapRef(cap_ptr.addr()));
-        }
-        drop(msg);
-        Ok(true)
-    }
-}
 
 #[derive(Default)]
 pub(crate) struct DomainEntry {

--- a/kernel/src/registry.rs
+++ b/kernel/src/registry.rs
@@ -1,0 +1,28 @@
+use abi::{Connect, Endpoint, Listen};
+
+use crate::KernelError;
+
+struct Registry {
+    index: heapless::FnvIndexMap<[u8; 10], Endpoint, 6>,
+}
+
+impl Registry {
+    fn listen(&mut self, listen: Listen, endpoint: Endpoint) -> Result<(), abi::Error> {
+        self.index
+            .insert(listen.port, endpoint)
+            .map_err(|_| abi::Error::BufferOverflow)?;
+        Ok(())
+    }
+
+    fn close(&mut self, port: [u8; 10]) -> Result<(), abi::Error> {
+        self.index.remove(&port).ok_or(abi::Error::BufferOverflow)?;
+        Ok(())
+    }
+
+    fn connect(&mut self, connect: Connect) -> Result<Endpoint, abi::Error> {
+        self.index
+            .get(&connect.port)
+            .ok_or(abi::Error::PortNotOpen)
+            .cloned()
+    }
+}

--- a/kernel/src/registry.rs
+++ b/kernel/src/registry.rs
@@ -1,25 +1,25 @@
-use abi::{Connect, Endpoint, Listen};
+use abi::{Connect, Endpoint, Listen, PortId};
 
-use crate::KernelError;
-
-struct Registry {
-    index: heapless::FnvIndexMap<[u8; 10], Endpoint, 6>,
+#[derive(Default)]
+pub(crate) struct Registry {
+    index: heapless::FnvIndexMap<PortId, Endpoint, 8>,
 }
 
 impl Registry {
-    fn listen(&mut self, listen: Listen, endpoint: Endpoint) -> Result<(), abi::Error> {
+    pub(crate) fn listen(&mut self, listen: Listen, endpoint: Endpoint) -> Result<(), abi::Error> {
         self.index
             .insert(listen.port, endpoint)
             .map_err(|_| abi::Error::BufferOverflow)?;
         Ok(())
     }
 
-    fn close(&mut self, port: [u8; 10]) -> Result<(), abi::Error> {
+    #[allow(dead_code)]
+    pub(crate) fn close(&mut self, port: PortId) -> Result<(), abi::Error> {
         self.index.remove(&port).ok_or(abi::Error::BufferOverflow)?;
         Ok(())
     }
 
-    fn connect(&mut self, connect: Connect) -> Result<Endpoint, abi::Error> {
+    pub(crate) fn connect(&mut self, connect: Connect) -> Result<Endpoint, abi::Error> {
         self.index
             .get(&connect.port)
             .ok_or(abi::Error::PortNotOpen)

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -1,0 +1,195 @@
+use super::KernelError;
+
+use crate::linked_impl;
+use crate::space::Space;
+use crate::task_ptr::TaskPtrMut;
+use crate::tcb::Tcb;
+use crate::{DomainEntry, ThreadState, PRIORITY_COUNT, TCB_CAPACITY};
+use abi::{RecvResp, ThreadRef};
+use alloc::boxed::Box;
+use cordyceps::{list::Links, List};
+use core::mem::MaybeUninit;
+use core::pin::Pin;
+
+pub(crate) struct Scheduler {
+    pub(crate) tcbs: Space<Tcb, TCB_CAPACITY>,
+    pub(crate) domains: [List<DomainEntry>; PRIORITY_COUNT],
+    pub(crate) exhausted_threads: List<ExhaustedThread>,
+    pub(crate) current_thread: ThreadTime,
+}
+
+impl Scheduler {
+    pub fn spawn(&mut self, tcb: Tcb) -> Result<ThreadRef, KernelError> {
+        let d = self
+            .domains
+            .get_mut(tcb.priority)
+            .ok_or(KernelError::InvalidPriority)?;
+        let tcb_ref = ThreadRef(self.tcbs.push(tcb).ok_or(KernelError::TooManyThreads)?);
+        d.push_back(Box::pin(DomainEntry {
+            tcb_ref: Some(tcb_ref),
+            ..Default::default()
+        }));
+        Ok(tcb_ref)
+    }
+
+    pub(crate) fn wait(
+        &mut self,
+        mask: usize,
+        out_buf: TaskPtrMut<'static, [u8]>,
+        recv_resp: TaskPtrMut<'static, MaybeUninit<RecvResp>>,
+    ) -> Result<ThreadRef, KernelError> {
+        let src = self.current_thread_mut()?;
+        src.state = ThreadState::Waiting {
+            addr: mask,
+            out_buf,
+            recv_resp,
+        };
+
+        self.wait_current_thread()
+    }
+
+    pub fn next_thread(&mut self, current_priority: usize) -> Option<ThreadRef> {
+        for domain in self
+            .domains
+            .iter_mut()
+            .rev()
+            .take(PRIORITY_COUNT - 1 - current_priority)
+        {
+            if let Some(thread) = domain.pop_front().and_then(|t| t.tcb_ref) {
+                return Some(thread);
+            }
+        }
+        None
+    }
+
+    pub fn add_thread(&mut self, priority: usize, tcb_ref: ThreadRef) -> Result<(), KernelError> {
+        let d = self
+            .domains
+            .get_mut(priority)
+            .ok_or(KernelError::InvalidPriority)?;
+        d.push_back(Box::pin(DomainEntry::new(tcb_ref)));
+        Ok(())
+    }
+
+    pub fn tick(&mut self) -> Result<Option<ThreadRef>, KernelError> {
+        // requeue exhausted threads
+        {
+            let mut cursor = self.exhausted_threads.cursor_front_mut();
+            cursor.move_prev(); // THIS IS PROBABLY WRONG
+            let mut remove_flag = false;
+            while let Some(t) = {
+                if remove_flag {
+                    cursor.remove_current();
+                }
+                cursor.move_next();
+                cursor.current_mut()
+            } {
+                if let Some(tcb_ref) = t.tcb_ref {
+                    if t.decrement() == 0 {
+                        remove_flag = true;
+                        let tcb = self
+                            .tcbs
+                            .get(*tcb_ref)
+                            .ok_or(KernelError::InvalidThreadRef)?;
+                        let d = self
+                            .domains
+                            .get_mut(tcb.priority)
+                            .ok_or(KernelError::InvalidPriority)?;
+                        d.push_back(Box::pin(DomainEntry::new(tcb_ref)));
+                    }
+                }
+            }
+        }
+        self.current_thread.time -= 1;
+        // check if current thread's budget has been surpassed
+        if self.current_thread.time == 0 {
+            let current_tcb = self
+                .tcbs
+                .get(*self.current_thread.tcb_ref)
+                .ok_or(KernelError::InvalidThreadRef)?;
+            let exhausted_thread = ExhaustedThread {
+                tcb_ref: Some(self.current_thread.tcb_ref),
+                time: current_tcb.cooldown,
+                _links: Default::default(),
+            };
+            self.exhausted_threads
+                .push_front(Box::pin(exhausted_thread));
+            let next_thread = self.next_thread(0).unwrap_or_else(ThreadRef::idle);
+            return self.switch_thread(next_thread).map(Some);
+        }
+        let current_tcb = self.current_thread()?;
+        let current_priority = current_tcb.priority;
+        if let Some(next_thread) = self.next_thread(current_priority) {
+            return self.switch_thread(next_thread).map(Some);
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn switch_thread(
+        &mut self,
+        next_thread: ThreadRef,
+    ) -> Result<ThreadRef, KernelError> {
+        let next_tcb = self
+            .tcbs
+            .get(*next_thread)
+            .ok_or(KernelError::InvalidThreadRef)?;
+        self.current_thread = ThreadTime {
+            tcb_ref: next_thread,
+            time: next_tcb.budget,
+        };
+        Ok(next_thread)
+    }
+
+    fn wait_current_thread(&mut self) -> Result<ThreadRef, KernelError> {
+        let next_thread = self.next_thread(0).unwrap_or_else(ThreadRef::idle);
+        self.switch_thread(next_thread)
+    }
+
+    #[inline]
+    pub fn current_thread(&self) -> Result<&Tcb, KernelError> {
+        self.get_tcb(self.current_thread.tcb_ref)
+    }
+
+    #[inline]
+    pub fn current_thread_mut(&mut self) -> Result<&mut Tcb, KernelError> {
+        self.get_tcb_mut(self.current_thread.tcb_ref)
+    }
+
+    #[inline]
+    pub fn get_tcb(&self, tcb_ref: ThreadRef) -> Result<&Tcb, KernelError> {
+        self.tcbs.get(*tcb_ref).ok_or(KernelError::InvalidThreadRef)
+    }
+
+    #[inline]
+    pub fn get_tcb_mut(&mut self, tcb_ref: ThreadRef) -> Result<&mut Tcb, KernelError> {
+        self.tcbs
+            .get_mut(*tcb_ref)
+            .ok_or(KernelError::InvalidThreadRef)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ExhaustedThread {
+    _links: Links<ExhaustedThread>,
+    time: usize,
+    tcb_ref: Option<ThreadRef>,
+}
+
+impl ExhaustedThread {
+    fn decrement(self: Pin<&mut ExhaustedThread>) -> usize {
+        // Safety: We never move the underlying memory, so this is safe
+        unsafe {
+            let s = self.get_unchecked_mut();
+            s.time -= 1;
+            s.time
+        }
+    }
+}
+
+linked_impl! { ExhaustedThread }
+
+#[derive(Debug)]
+pub(crate) struct ThreadTime {
+    pub(crate) tcb_ref: ThreadRef,
+    pub(crate) time: usize,
+}

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -1,0 +1,321 @@
+use core::mem::{self, MaybeUninit};
+
+use abi::{
+    CapListEntry, CapRef, RecvResp, SyscallArgs, SyscallDataType, SyscallReturnType, ThreadRef,
+};
+use defmt::error;
+
+use crate::{
+    task::TaskState,
+    task_ptr::{TaskPtr, TaskPtrMut},
+    tcb::Tcb,
+    CapEntry, Kernel, KernelError,
+};
+
+#[repr(C)]
+pub(crate) struct SendCall {
+    buf_addr: usize,
+    buf_len: usize,
+    cap_ref: CapRef,
+}
+
+pub unsafe trait SysCall {
+    #[inline]
+    fn from_args(args: &SyscallArgs) -> &Self
+    where
+        Self: Sized,
+    {
+        unsafe { mem::transmute(args) }
+    }
+    fn exec(&self, arg_type: SyscallDataType, kern: &mut Kernel)
+        -> Result<CallReturn, KernelError>;
+}
+
+// Safety: The only requirement for safety in this trait is that the implementer has the same alignment and less than or equal length as [`SyscallArgs`]
+unsafe impl SysCall for SendCall {
+    #[inline]
+    fn from_args(args: &SyscallArgs) -> &Self {
+        unsafe { mem::transmute(args) }
+    }
+
+    #[inline]
+    fn exec(
+        &self,
+        arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        if arg_type == SyscallDataType::Page {
+            todo!()
+        }
+        let tcb = kern.scheduler.current_thread()?;
+        let slice = get_buf::<1024>(kern, tcb, self.buf_addr, self.buf_len)?;
+        let msg = alloc::boxed::Box::from(slice);
+        let priority = tcb.priority;
+        kern.send(self.cap_ref, msg)?;
+        let next_thread = kern.scheduler.next_thread(priority);
+        Ok(match next_thread {
+            Some(next_thread) => CallReturn::Switch {
+                next_thread,
+                ret: abi::SyscallReturn::new()
+                    .with(abi::SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
+            },
+            None => CallReturn::Return {
+                ret: abi::SyscallReturn::new()
+                    .with(abi::SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
+            },
+        })
+    }
+}
+
+#[repr(C)]
+pub(crate) struct CallSysCall {
+    in_addr: usize,
+    in_len: usize,
+    cap_ref: CapRef,
+    resp_addr: usize,
+    out_addr: usize,
+    out_len: usize,
+}
+
+// Safety: The only requirement for safety in this trait is that the implementer has the same alignment and less than or equal length as [`SyscallArgs`]
+unsafe impl SysCall for CallSysCall {
+    #[inline]
+    fn exec(
+        &self,
+        arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        if arg_type == SyscallDataType::Page {
+            todo!()
+        }
+        let tcb = kern.scheduler.current_thread()?;
+        let slice = get_buf::<1024>(kern, tcb, self.in_addr, self.in_len)?;
+        let msg = alloc::boxed::Box::from(slice);
+        // Safety: the caller is giving over memory to us, to overwrite
+        // TaskPtrMut ensures that the memory belongs to the correct task
+        let out_buf =
+            unsafe { TaskPtrMut::<'_, [u8]>::from_raw_parts(self.out_addr, self.out_len) };
+        // Safety: the caller is giving over memory to us, to overwrite
+        // TaskPtrMut ensures that the memory belongs to the correct task
+        let recv_resp =
+            unsafe { TaskPtrMut::<'_, MaybeUninit<RecvResp>>::from_raw_parts(self.resp_addr, ()) };
+        let next_thread = kern.call(self.cap_ref, msg, out_buf, recv_resp)?;
+        Ok(CallReturn::Switch {
+            next_thread: kern.scheduler.switch_thread(next_thread)?,
+            ret: abi::SyscallReturn::new(),
+        })
+    }
+}
+
+#[repr(C)]
+pub(crate) struct RecvCall {
+    out_addr: usize,
+    out_len: usize,
+    mask: usize,
+    resp_addr: usize,
+}
+
+// Safety: The only requirement for safety in this trait is that the implementer has the same alignment and less than or equal length as [`SyscallArgs`]
+unsafe impl SysCall for RecvCall {
+    fn exec(
+        &self,
+        arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        if arg_type == SyscallDataType::Page {
+            todo!()
+        }
+        let out_buf =
+        // Safety: the caller is giving over memory to us, to overwrite
+        // TaskPtrMut ensures that the memory belongs to the correct task
+            unsafe { TaskPtrMut::<'_, [u8]>::from_raw_parts(self.out_addr, self.out_len as usize) };
+        // Safety: the caller is giving over memory to us, to overwrite
+        // TaskPtrMut ensures that the memory belongs to the correct task
+        let recv_resp =
+            unsafe { TaskPtrMut::<'_, MaybeUninit<RecvResp>>::from_raw_parts(self.resp_addr, ()) };
+        let tcb = kern.scheduler.current_thread_mut()?;
+        let task = kern
+            .tasks
+            .get(tcb.task.0)
+            .ok_or(KernelError::InvalidTaskRef)?;
+        if !tcb.recv(task, self.mask, out_buf, recv_resp)? {
+            // Safety: the caller is giving over memory to us, to overwrite
+            // TaskPtrMut ensures that the memory belongs to the correct task
+            let out_buf =
+                unsafe { TaskPtrMut::<'_, [u8]>::from_raw_parts(self.out_addr, self.out_len) };
+            // Safety: the caller is giving over memory to us, to overwrite
+            // TaskPtrMut ensures that the memory belongs to the correct task
+            let recv_resp = unsafe {
+                TaskPtrMut::<'_, MaybeUninit<RecvResp>>::from_raw_parts(self.resp_addr, ())
+            };
+            Ok(CallReturn::Replace {
+                next_thread: kern.scheduler.wait(self.mask, out_buf, recv_resp)?,
+            })
+        } else {
+            Ok(CallReturn::Return {
+                ret: abi::SyscallReturn::new(),
+            })
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct LogCall {
+    in_addr: usize,
+    in_len: usize,
+}
+
+// Safety: The only requirement for safety in this trait is that the implementer has the same alignment and less than or equal length as [`SyscallArgs`]
+unsafe impl SysCall for LogCall {
+    fn exec(
+        &self,
+        _arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        let tcb = kern.scheduler.current_thread()?;
+
+        let log_buf = get_buf::<255>(kern, tcb, self.in_addr, self.in_len)?;
+        crate::defmt_log::log(tcb.task.0 as u8 + 1, log_buf);
+        Ok(CallReturn::Return {
+            ret: abi::SyscallReturn::new(),
+        })
+    }
+}
+
+#[repr(C)]
+pub(crate) struct CapsCall {
+    out_addr: usize,
+    out_len: usize,
+}
+
+// Safety: The only requirement for safety in this trait is that the implementer has the same alignment and less than or equal length as [`SyscallArgs`]
+unsafe impl SysCall for CapsCall {
+    fn exec(
+        &self,
+        _arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        let tcb = kern.scheduler.current_thread()?;
+        let task = kern.task(tcb.task)?;
+        let slice = unsafe {
+            TaskPtrMut::<'_, [CapListEntry]>::from_raw_parts(self.out_addr, self.out_len)
+        };
+        let slice = task
+            .validate_mut_ptr(slice)
+            .ok_or(KernelError::InvalidTaskPtr)?;
+
+        let len = slice.len().min(tcb.capabilities.len());
+        for (i, entry) in tcb.capabilities.iter().take(len).enumerate() {
+            slice[i] = abi::CapListEntry {
+                cap_ref: CapRef((entry as *const CapEntry).addr()),
+                desc: entry.cap.clone(),
+            };
+        }
+        let ret = abi::SyscallReturn::new()
+            .with(abi::SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy)
+            .with(abi::SyscallReturn::SYSCALL_LEN, len as u64);
+        Ok(CallReturn::Return { ret })
+    }
+}
+
+#[repr(C)]
+pub(crate) struct PanikCall {}
+
+unsafe impl SysCall for PanikCall {
+    fn exec(
+        &self,
+        _arg_type: SyscallDataType,
+        kern: &mut Kernel,
+    ) -> Result<CallReturn, KernelError> {
+        let tcb = kern.scheduler.current_thread()?;
+        let task_ref = tcb.task;
+        error!("task {:?} paniked", task_ref.0);
+        for domain in &mut kern.scheduler.domains {
+            let mut cursor = domain.cursor_front_mut();
+            cursor.move_prev();
+            while let Some(entry) = { cursor.next() } {
+                if entry
+                    .tcb_ref
+                    .and_then(|t| kern.scheduler.tcbs.get(*t))
+                    .is_some()
+                {
+                    cursor.remove_current();
+                }
+            }
+        }
+        let mut priority = None;
+        let mut budget = None;
+        let mut cooldown = None;
+        let task = kern
+            .tasks
+            .get_mut(task_ref.0)
+            .ok_or(KernelError::InvalidTaskRef)?;
+        task.state = TaskState::Pending;
+        task.reset_stack_ptr();
+        let task = kern
+            .tasks
+            .get(task_ref.0)
+            .ok_or(KernelError::InvalidTaskRef)?;
+        for i in 0..16 {
+            if let Some(tcb) = kern.scheduler.tcbs.get(i) {
+                if tcb.task == task_ref {
+                    if tcb.entrypoint == task.entrypoint.addr() {
+                        priority = Some(tcb.priority);
+                        budget = Some(tcb.budget);
+                        cooldown = Some(tcb.cooldown);
+                    }
+                    kern.scheduler.tcbs.remove(i);
+                }
+            }
+        }
+        let (priority, budget, cooldown) = if let Some(priority) = priority && let Some(budget) = budget && let Some(cooldown) = cooldown {
+                    (priority, budget, cooldown)
+                }else {
+                    return Err(KernelError:: InitTCBNotFound);
+                };
+        kern.spawn_thread(task_ref, priority, budget, cooldown, task.entrypoint)?;
+        let next_thread = kern
+            .scheduler
+            .next_thread(0)
+            .unwrap_or_else(ThreadRef::idle);
+        let next_thread = kern.scheduler.switch_thread(next_thread)?;
+        Ok(CallReturn::Replace { next_thread })
+    }
+}
+
+fn get_buf<'t, const N: usize>(
+    kern: &Kernel,
+    tcb: &'t Tcb,
+    addr: usize,
+    len: usize,
+) -> Result<&'t [u8], KernelError> {
+    let task = kern
+        .tasks
+        .get(tcb.task.0)
+        .ok_or(KernelError::InvalidTaskRef)?;
+    // Safety: the caller is giving over memory to us, to overwrite
+    // TaskPtrMut ensures that the memory belongs to the correct task
+    let slice = unsafe { TaskPtr::<'_, [u8]>::from_raw_parts(addr, len) };
+    let slice = if let Some(buf) = task.validate_ptr(slice) {
+        buf
+    } else {
+        return Err(KernelError::ABI(abi::Error::BadAccess));
+    };
+    if slice.len() > N {
+        return Err(KernelError::ABI(abi::Error::BufferOverflow));
+    }
+    Ok(slice)
+}
+
+pub enum CallReturn {
+    Replace {
+        next_thread: ThreadRef,
+    },
+    Switch {
+        next_thread: ThreadRef,
+        ret: abi::SyscallReturn,
+    },
+    Return {
+        ret: abi::SyscallReturn,
+    },
+}

--- a/kernel/src/task.rs
+++ b/kernel/src/task.rs
@@ -1,0 +1,90 @@
+use crate::arch;
+use crate::regions::RegionTable;
+use crate::task_ptr::{TaskPtr, TaskPtrMut};
+use core::ops::Range;
+use heapless::Vec;
+
+#[repr(C)]
+#[derive(Clone)]
+pub(crate) struct Task {
+    pub(crate) region_table: RegionTable,
+    pub(crate) stack_size: usize,
+    pub(crate) initial_stack_ptr: Range<usize>,
+    pub(crate) available_stack_ptr: Vec<Range<usize>, 8>,
+    pub(crate) entrypoint: TaskPtr<'static, fn() -> !>,
+    pub(crate) secure: bool,
+    pub(crate) state: TaskState,
+}
+
+#[repr(u8)]
+#[derive(Clone, PartialEq)]
+pub(crate) enum TaskState {
+    Pending,
+    Started,
+}
+
+impl Task {
+    pub(crate) fn new(
+        region_table: RegionTable,
+        stack_size: usize,
+        initial_stack_ptr: Range<usize>,
+        entrypoint: TaskPtr<'static, fn() -> !>,
+        secure: bool,
+    ) -> Self {
+        Self {
+            region_table,
+            stack_size,
+            available_stack_ptr: Vec::from_slice(&[initial_stack_ptr.clone()]).unwrap(),
+            initial_stack_ptr,
+            secure,
+            entrypoint,
+            state: TaskState::Pending,
+        }
+    }
+
+    pub(crate) fn reset_stack_ptr(&mut self) {
+        self.available_stack_ptr = Vec::from_slice(&[self.initial_stack_ptr.clone()]).unwrap()
+    }
+
+    pub(crate) fn validate_ptr<'a, T: core::ptr::Pointee + ?Sized>(
+        &self,
+        ptr: TaskPtr<'a, T>,
+    ) -> Option<&'a T> {
+        arch::translate_task_ptr(ptr, self)
+    }
+
+    pub(crate) fn validate_mut_ptr<'a, T: core::ptr::Pointee + ?Sized>(
+        &self,
+        ptr: TaskPtrMut<'a, T>,
+    ) -> Option<&'a mut T> {
+        arch::translate_mut_task_ptr(ptr, self)
+    }
+
+    pub(crate) fn alloc_stack(&mut self) -> Option<usize> {
+        for range in &mut self.available_stack_ptr {
+            if range.len() >= self.stack_size {
+                range.start += self.stack_size;
+                return Some(range.start);
+                //TODO: cleanup empty ranges might need to use LL
+            }
+        }
+        None
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn make_stack_available(&mut self, stack_start: usize) {
+        for range in &mut self.available_stack_ptr {
+            if range.start == stack_start + self.stack_size {
+                range.start = stack_start;
+                return;
+            }
+            if range.end == stack_start {
+                range.end = stack_start + self.stack_size;
+                return;
+            }
+        }
+        let _ = self
+            .available_stack_ptr
+            .push(stack_start..stack_start + self.stack_size);
+    }
+}

--- a/kernel/src/tcb.rs
+++ b/kernel/src/tcb.rs
@@ -1,0 +1,144 @@
+use core::mem::MaybeUninit;
+
+use abi::{Cap, CapRef, Endpoint, RecvResp, SyscallReturn, SyscallReturnType};
+use alloc::boxed::Box;
+use cordyceps::{list::Links, List};
+
+use crate::{
+    arch, task_ptr::TaskPtrMut, CapEntry, IPCMsg, KernelError, Task, TaskRef, ThreadState,
+};
+
+#[repr(C)]
+pub(crate) struct Tcb {
+    pub(crate) saved_state: arch::SavedThreadState,
+    pub(crate) task: TaskRef, // Maybe use RC for this
+    pub(crate) req_queue: List<IPCMsg>,
+    pub(crate) state: ThreadState,
+    pub(crate) priority: usize,
+    pub(crate) budget: usize,
+    pub(crate) cooldown: usize,
+    pub(crate) capabilities: List<CapEntry>,
+    pub(crate) stack_pointer: usize,
+    pub(crate) entrypoint: usize,
+    pub(crate) epoch: usize,
+}
+
+impl Tcb {
+    pub fn new(
+        task: TaskRef,
+        stack_pointer: usize,
+        priority: usize,
+        budget: usize,
+        cooldown: usize,
+        entrypoint: usize,
+        epoch: usize,
+    ) -> Self {
+        Self {
+            task,
+            //_pad: 0,
+            req_queue: List::new(),
+            //reply_queue: List::new(),
+            state: ThreadState::Ready,
+            priority,
+            budget,
+            cooldown,
+            capabilities: List::new(),
+            stack_pointer,
+            entrypoint,
+            saved_state: Default::default(),
+            epoch,
+        }
+    }
+
+    #[inline]
+    fn cap_entry(&self, cap_ref: CapRef) -> Result<&CapEntry, KernelError> {
+        for c in self.capabilities.iter() {
+            let c_addr = (c as *const CapEntry).addr();
+            if c_addr == *cap_ref {
+                return Ok(c);
+            }
+        }
+        Err(KernelError::InvalidCapRef)
+    }
+
+    #[allow(dead_code)]
+    fn capability(&self, cap_ref: CapRef) -> Result<&Cap, KernelError> {
+        self.cap_entry(cap_ref).map(|e| &e.cap)
+    }
+
+    pub(crate) fn endpoint(&mut self, cap_ref: CapRef) -> Result<Endpoint, KernelError> {
+        let dest_cap = self.cap_entry(cap_ref)?;
+        let endpoint = if let Cap::Endpoint(endpoint) = dest_cap.cap {
+            endpoint
+        } else {
+            return Err(KernelError::WrongCapabilityType);
+        };
+        if endpoint.disposable {
+            // Safety: this function is marked as unsafe, because the user must guarentee that
+            // the item is in the list. dest_cap comes from self.capabilities, so this is safe
+            unsafe {
+                self.capabilities.remove(dest_cap.into());
+            }
+        }
+        Ok(endpoint)
+    }
+
+    pub(crate) fn add_cap(&mut self, cap: Cap) {
+        self.capabilities.push_back(Box::pin(CapEntry {
+            _links: Links::default(),
+            cap,
+        }));
+    }
+
+    pub(crate) fn recv(
+        &mut self,
+        task: &Task,
+        mask: usize,
+        out_buf: TaskPtrMut<'_, [u8]>,
+        recv_resp: TaskPtrMut<'_, MaybeUninit<RecvResp>>,
+    ) -> Result<bool, KernelError> {
+        let mut cursor = self.req_queue.cursor_front_mut();
+        cursor.move_prev();
+        let mut found = false;
+        while let Some(msg) = {
+            cursor.move_next();
+            cursor.current()
+        } {
+            if msg.addr & mask == mask {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Ok(false);
+        }
+        let msg = cursor.remove_current().unwrap(); // found will only ever be set when there is a msg
+        let out_buf = task
+            .validate_mut_ptr(out_buf)
+            .ok_or(KernelError::InvalidTaskPtr)?;
+        let inner = &msg.inner.as_ref().unwrap();
+        if out_buf.len() != inner.body.len() {
+            self.saved_state
+                .set_syscall_return(abi::Error::ReturnTypeMismatch.into());
+            return Ok(true);
+        }
+        out_buf.copy_from_slice(&inner.body);
+        self.saved_state.set_syscall_return(
+            SyscallReturn::new().with(SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
+        );
+        let recv_resp = task
+            .validate_mut_ptr(recv_resp)
+            .ok_or(KernelError::InvalidTaskPtr)?; // TODO: make syscall return
+        let recv_resp = recv_resp.write(RecvResp {
+            cap: None,
+            inner: abi::RecvRespInner::Copy(inner.body.len()),
+        });
+        if let Some(reply) = inner.reply_endpoint {
+            self.add_cap(Cap::Endpoint(reply));
+            let cap_ptr = &*self.capabilities.back().unwrap() as *const CapEntry;
+            recv_resp.cap = Some(CapRef(cap_ptr.addr()));
+        }
+        drop(msg);
+        Ok(true)
+    }
+}


### PR DESCRIPTION
The "registry" is a place where tasks can advertise that they are open for messages. You can register a "port" (a 16 byte id) into the registry using the `listen` syscall. When another task wishes to send to a listening task, they call `connect`. `connect` will return an `Endpoint` the task can then send to. 