### PR TITLE
Add memory loans, and support passing peripherals to task's

### DIFF
--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -148,6 +148,7 @@ pub enum Error {
     BufferOverflow,
     PortNotOpen,
     InvalidCap,
+    InvalidLoan,
     Unknown(u8),
 }
 
@@ -159,6 +160,7 @@ impl From<u8> for Error {
             3 => Error::BufferOverflow,
             4 => Error::PortNotOpen,
             5 => Error::InvalidCap,
+            6 => Error::InvalidLoan,
             code => Error::Unknown(code),
         }
     }
@@ -172,6 +174,7 @@ impl From<Error> for u8 {
             Error::BufferOverflow => 3,
             Error::PortNotOpen => 4,
             Error::InvalidCap => 5,
+            Error::InvalidLoan => 6,
             Error::Unknown(code) => code,
         }
     }

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -15,7 +15,7 @@ mycelium_bitfield::bitfield! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, defmt::Format, PartialEq)]
 #[repr(u8)]
 pub enum SyscallFn {
     Send = 0x0,
@@ -98,7 +98,7 @@ pub enum SyscallReturnType {
 }
 
 mycelium_bitfield::bitfield! {
-    #[derive( Eq, PartialEq)]
+    #[derive( Eq, PartialEq, Format)]
     pub struct SyscallReturn<u64> {
         pub const SYSCALL_TYPE: SyscallReturnType;
         pub const SYSCALL_LEN = 22;

--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -198,7 +198,7 @@ impl From<usize> for CapRef {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, defmt::Format)]
+#[derive(Clone, Copy, Debug, PartialEq, defmt::Format, Eq)]
 #[repr(C)]
 pub struct ThreadRef(pub usize);
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -16,7 +16,7 @@ This page will give an overview of each component, more details can be found in 
 
 ## Scheduler
 
-K5's scheduler is heavily based on the MCS system from seL4, which is intern based on ["Aperiodic task scheduling for real-time systems"](https://trustworthy.systems/publications/csiro_full_text/Lyons_MAH_18.pdf) by Brinkely Sprunt. There are some minor, but important, differences between MCS and k5 system. Both schedulers attempt to solve the problem of a high-priority task monopolizing CPU-time, and they solve this problem in fundemntally the same way.
+K5's scheduler is heavily based on the MCS system from seL4, which is intern based on ["Scheduling-Context Capabilities"](https://trustworthy.systems/publications/csiro_full_text/Lyons_MAH_18.pdf) by Anna Lyons, et all. There are some minor, but important, differences between MCS and k5 system. Both schedulers attempt to solve the problem of a high-priority task monopolizing CPU-time, and they solve this problem in fundemntally the same way.
 
 In K5 each task is given a priority, a budget, and a cooldown. Threads are scheduled in a round-robin fashion in decending order of priority (7 is the highest, while 0 is the lowest). When a thread is first scheduled on the CPU, it is given an amount of time it is allowed to execute, its budget. Each tick this budget is reduced, when it reaches zero the thread is "exhausted" and execution is paused. It is then added to queue of exhausted threads. Each tick the exhausted list is scanned for threads whose cooldown has elapsed, once a cooldown is elapsed the thread is rescheduled. This technique is almost identical to MCS with some terminology differences. MCS has a "period" which is equivalent to k5's `budget + cooldown`. 
 

--- a/examples/bar/src/main.rs
+++ b/examples/bar/src/main.rs
@@ -15,7 +15,7 @@ pub fn main() -> ! {
     let mut a: u32 = 20;
     loop {
         a += 1;
-        if a % 50000 == 0 {
+        if a % 100000 == 0 {
             let mut buf = [0xFFu8; 10];
             buf[0..4].copy_from_slice(&a.to_be_bytes());
             info!("send {:?}", buf);

--- a/examples/foo/Cargo.toml
+++ b/examples/foo/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 defmt = "0.3"
 userspace = { path = "../../userspace" }
+stm32-hal2 = { version = "^1.5.0", features = ["l562"]}

--- a/examples/stm32l5/Cargo.toml
+++ b/examples/stm32l5/Cargo.toml
@@ -13,6 +13,8 @@ cortex-m-rt = "0.7"
 kernel = { path = "../../kernel" }
 abi = { path = "../../abi" }
 defmt = { version = "0.3", features = ["encoding-raw"] }
+stm32l5 = { version = "0.15", features = ["stm32l562"], default-features = false }
+
 
 [build-dependencies]
 codegen = { path =  "../../codegen" }

--- a/examples/stm32l5/src/main.rs
+++ b/examples/stm32l5/src/main.rs
@@ -28,6 +28,7 @@ fn main() -> ! {
 
     let mut kernel = kernel::KernelBuilder::new(task_table::TASKS);
     let _idle = kernel.idle_thread(task_table::IDLE);
+
     let bar_thread = kernel.thread(
         task_table::BAR
             .priority(7)
@@ -35,7 +36,6 @@ fn main() -> ! {
             .cooldown(50)
             .connect(*b"0123456789abcdef"),
     );
-
     let foo_thread = kernel.thread(
         task_table::FOO
             .priority(7)
@@ -49,6 +49,7 @@ fn main() -> ! {
             .loan_mem(RegionBuilder::device(stm32l562::FLASH::PTR).write().read())
             .listen(*b"0123456789abcdef"),
     );
+
     kernel.endpoint(bar_thread, foo_thread, 0);
     info!("booting");
     kernel.start()

--- a/examples/stm32l5/src/main.rs
+++ b/examples/stm32l5/src/main.rs
@@ -6,8 +6,10 @@ extern crate alloc;
 
 use alloc_cortex_m::CortexMHeap;
 use core::{mem::MaybeUninit, panic::PanicInfo};
-use cortex_m_rt::entry;
+use cortex_m_rt::{entry, exception};
 use defmt::{error, info};
+use kernel::RegionBuilder;
+use stm32l5::stm32l562;
 
 kernel::include_task_table! {}
 
@@ -23,21 +25,28 @@ fn main() -> ! {
         // Safety: we only ever access this once durring init, so this operation is safe
         crate::ALLOCATOR.init(unsafe { HEAP })
     }
+
     let mut kernel = kernel::KernelBuilder::new(task_table::TASKS);
     let _idle = kernel.idle_thread(task_table::IDLE);
     let bar_thread = kernel.thread(
         task_table::BAR
             .priority(7)
-            .budget(20)
-            .cooldown(10)
+            .budget(100)
+            .cooldown(50)
             .connect(*b"0123456789abcdef"),
     );
 
     let foo_thread = kernel.thread(
         task_table::FOO
             .priority(7)
-            .budget(1)
+            .budget(5)
             .cooldown(usize::MAX)
+            .loan_mem(RegionBuilder::device(stm32l562::RCC::PTR).write().read())
+            .loan_mem(RegionBuilder::device(stm32l562::GPIOA::PTR).write().read())
+            .loan_mem(RegionBuilder::device(stm32l562::GPIOD::PTR).write().read())
+            .loan_mem(RegionBuilder::device(stm32l562::GPIOG::PTR).write().read())
+            .loan_mem(RegionBuilder::device(stm32l562::PWR::PTR).write().read())
+            .loan_mem(RegionBuilder::device(stm32l562::FLASH::PTR).write().read())
             .listen(*b"0123456789abcdef"),
     );
     kernel.endpoint(bar_thread, foo_thread, 0);
@@ -59,4 +68,23 @@ fn panic(info: &PanicInfo) -> ! {
     loop {
         cortex_m::asm::bkpt();
     }
+}
+
+#[exception]
+unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
+    defmt::println!("{:?}", defmt::Debug2Format(ef));
+    defmt::println!(
+        "MemFault reg {:b}",
+        core::ptr::read_volatile(0xE000ED28 as *const u16)
+    );
+    defmt::println!(
+        "MemFault addr: {:x}",
+        core::ptr::read_volatile(0xE000ED34 as *const u32)
+    );
+    defmt::println!(
+        "UsageFault reg {:b}",
+        core::ptr::read_volatile(0xE000ED2A as *const u16)
+    );
+
+    loop {}
 }

--- a/kernel/src/arch/cortex_m.rs
+++ b/kernel/src/arch/cortex_m.rs
@@ -65,7 +65,8 @@ pub(crate) fn start_root_task(task: &Task, tcb: &Tcb) -> ! {
     // since if called in an interrupt handler it can lead to some bad side-effects
     // This whole function is only called once from `main`, so its safe
     unsafe {
-        p.SCB.set_priority(SystemHandler::SysTick, 0xff);
+        p.SCB.set_priority(SystemHandler::SVCall, 0xFF);
+        p.SCB.set_priority(SystemHandler::SysTick, 0xFF);
     }
 
     let irq_count = (((p.ICB.ictr.read() & 0xF) + 1) * 32) as usize;
@@ -81,7 +82,7 @@ pub(crate) fn start_root_task(task: &Task, tcb: &Tcb) -> ! {
         }
     }
 
-    p.SYST.set_reload(400_000);
+    p.SYST.set_reload(20_000);
     p.SYST.clear_current();
     p.SYST.enable_counter();
     p.SYST.enable_interrupt();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,7 @@ mod task;
 mod task_ptr;
 mod tcb;
 
+use defmt::Format;
 use registry::Registry;
 use syscalls::{
     CallReturn, CallSysCall, CapsCall, ConnectCall, ListenCall, LogCall, PanikCall, RecvCall,
@@ -41,11 +42,7 @@ use cordyceps::{
     list::{self, Links},
     List,
 };
-use core::{
-    mem::{self, MaybeUninit},
-    ops::Range,
-    pin::Pin,
-};
+use core::{mem::MaybeUninit, ops::Range, pin::Pin};
 use heapless::Vec;
 use regions::{Region, RegionAttr, RegionTable};
 use scheduler::{Scheduler, ThreadTime};
@@ -53,7 +50,6 @@ use space::Space;
 use task::*;
 use task_ptr::{TaskPtr, TaskPtrMut};
 
-pub(crate) const PRIORITY_COUNT: usize = 8;
 pub(crate) const TCB_CAPACITY: usize = 16;
 
 pub struct Kernel {
@@ -191,10 +187,6 @@ impl Kernel {
                     .add_thread(dest_tcb_priority, endpoint.tcb_ref)?;
             }
         } else if is_call {
-            let task = self
-                .tasks
-                .get(dest_tcb.task.0)
-                .ok_or(KernelError::InvalidTaskRef)?;
             let dest_tcb_priority = dest_tcb.priority;
             self.scheduler
                 .add_thread(dest_tcb_priority, endpoint.tcb_ref)?;
@@ -289,7 +281,7 @@ pub enum KernelError {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct TaskRef(pub usize);
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug, Format)]
 pub(crate) struct DomainEntry {
     tcb_ref: ThreadRef,
     loaned_tcb: Option<ThreadRef>,

--- a/kernel/src/regions.rs
+++ b/kernel/src/regions.rs
@@ -45,7 +45,8 @@ impl RegionTable {
             }
             if inserted_at.is_none()
                 && region.range.start > self.regions[i].range.end
-                && region.range.end < self.regions[i + 1].range.start
+                && ((i == self.regions.len() - 1)
+                    || region.range.end < self.regions[i + 1].range.start)
             {
                 inserted_at = Some(i);
             }

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -27,8 +27,9 @@ impl Scheduler {
             .ok_or(KernelError::InvalidPriority)?;
         let tcb_ref = ThreadRef(self.tcbs.push(tcb).ok_or(KernelError::TooManyThreads)?);
         d.push_back(Box::pin(DomainEntry {
-            tcb_ref: Some(tcb_ref),
-            ..Default::default()
+            tcb_ref,
+            _links: Default::default(),
+            loaned_tcb: None,
         }));
         Ok(tcb_ref)
     }
@@ -47,19 +48,26 @@ impl Scheduler {
             recv_resp,
         };
 
-        let next_thread = self.next_thread(0).unwrap_or_else(ThreadRef::idle);
-        self.switch_thread(next_thread, loan)
+        let mut next_thread = self.next_thread(0).unwrap_or_else(DomainEntry::idle);
+        if loan {
+            next_thread.loaned_tcb = Some(self.current_thread.tcb_ref)
+        }
+        self.switch_thread(next_thread)
     }
 
-    pub fn next_thread(&mut self, current_priority: usize) -> Option<ThreadRef> {
+    pub fn next_thread(&mut self, current_priority: usize) -> Option<DomainEntry> {
         for domain in self
             .domains
             .iter_mut()
             .rev()
             .take(PRIORITY_COUNT - 1 - current_priority)
         {
-            if let Some(thread) = domain.pop_front().and_then(|t| t.tcb_ref) {
-                return Some(thread);
+            if let Some(thread) = domain.pop_front() {
+                return Some(DomainEntry {
+                    _links: Default::default(),
+                    tcb_ref: thread.tcb_ref,
+                    loaned_tcb: thread.loaned_tcb,
+                });
             }
         }
         None
@@ -70,11 +78,12 @@ impl Scheduler {
             .domains
             .get_mut(priority)
             .ok_or(KernelError::InvalidPriority)?;
-        d.push_back(Box::pin(DomainEntry::new(tcb_ref)));
+        d.push_back(Box::pin(DomainEntry::new(tcb_ref, None)));
         Ok(())
     }
 
     pub fn tick(&mut self) -> Result<Option<ThreadRef>, KernelError> {
+        defmt::trace!("tick");
         // requeue exhausted threads
         {
             let mut cursor = self.exhausted_threads.cursor_front_mut();
@@ -88,6 +97,7 @@ impl Scheduler {
                 cursor.current_mut()
             } {
                 if let Some(tcb_ref) = t.tcb_ref {
+                    let loaned_tcb = t.loaned_tcb;
                     let time = t.decrement();
                     defmt::trace!("decrement exhausted thread: {:?} {:?}", tcb_ref, time);
                     if time == 0 {
@@ -100,7 +110,7 @@ impl Scheduler {
                             .domains
                             .get_mut(tcb.priority)
                             .ok_or(KernelError::InvalidPriority)?;
-                        d.push_back(Box::pin(DomainEntry::new(tcb_ref)));
+                        d.push_back(Box::pin(DomainEntry::new(tcb_ref, loaned_tcb)));
                     }
                 }
             }
@@ -111,31 +121,31 @@ impl Scheduler {
         if self.current_thread.time == 0 {
             let current_tcb = self
                 .tcbs
-                .get(*self.current_thread.tcb_ref)
+                .get(*self.current_thread.time_thread())
                 .ok_or(KernelError::InvalidThreadRef)?;
             let exhausted_thread = ExhaustedThread {
                 tcb_ref: Some(self.current_thread.tcb_ref),
                 time: current_tcb.cooldown,
+                loaned_tcb: self.current_thread.loaned_tcb,
                 _links: Default::default(),
             };
             self.exhausted_threads
                 .push_front(Box::pin(exhausted_thread));
             defmt::trace!("exhausting: {:?}", self.current_thread);
-            let next_thread = self.next_thread(0).unwrap_or_else(ThreadRef::idle);
-            return self.switch_thread(next_thread, false).map(Some);
+            let next_thread = self.next_thread(0).unwrap_or_else(DomainEntry::idle);
+            return self.switch_thread(next_thread).map(Some);
         }
         let current_tcb = self.current_thread()?;
         let current_priority = current_tcb.priority;
         if let Some(next_thread) = self.next_thread(current_priority) {
-            return self.switch_thread(next_thread, false).map(Some);
+            return self.switch_thread(next_thread).map(Some);
         }
         Ok(None)
     }
 
     pub(crate) fn switch_thread(
         &mut self,
-        next_thread: ThreadRef,
-        loan: bool,
+        next_thread: DomainEntry,
     ) -> Result<ThreadRef, KernelError> {
         let loaned_tcb = if let Some(loaned) = self.current_thread.loaned_tcb {
             self.tcbs
@@ -149,30 +159,25 @@ impl Scheduler {
         loaned_tcb.rem_time = self.current_thread.time;
         // NOTE: we might want to just monomorphize this out, rather than
         // using an if statement
-        let time_tcb = if loan {
-            self.tcbs
-                .get(*self.current_thread.tcb_ref)
-                .ok_or(KernelError::InvalidThreadRef)?
-        } else {
-            self.tcbs
-                .get(*next_thread)
-                .ok_or(KernelError::InvalidThreadRef)?
-        };
+        let time_tcb = self
+            .tcbs
+            .get(*next_thread.loaned_tcb.unwrap_or(next_thread.tcb_ref))
+            .ok_or(KernelError::InvalidThreadRef)?;
         defmt::trace!(
             "switching: {:?} -> {:?}",
             self.current_thread.tcb_ref,
-            next_thread
+            next_thread.tcb_ref,
         );
         self.current_thread = ThreadTime {
-            tcb_ref: next_thread,
+            tcb_ref: next_thread.tcb_ref,
             time: if time_tcb.rem_time > 0 {
                 time_tcb.rem_time
             } else {
                 time_tcb.budget
             },
-            loaned_tcb: loan.then_some(self.current_thread.tcb_ref),
+            loaned_tcb: next_thread.loaned_tcb,
         };
-        Ok(next_thread)
+        Ok(next_thread.tcb_ref)
     }
 
     #[inline]
@@ -203,6 +208,7 @@ pub(crate) struct ExhaustedThread {
     _links: Links<ExhaustedThread>,
     time: usize,
     tcb_ref: Option<ThreadRef>,
+    pub(crate) loaned_tcb: Option<ThreadRef>,
 }
 
 impl ExhaustedThread {
@@ -214,6 +220,10 @@ impl ExhaustedThread {
             s.time
         }
     }
+
+    fn loaned_tcb(self: &Pin<&mut ExhaustedThread>) -> Option<ThreadRef> {
+        self.loaned_tcb
+    }
 }
 
 linked_impl! { ExhaustedThread }
@@ -223,4 +233,10 @@ pub(crate) struct ThreadTime {
     pub(crate) tcb_ref: ThreadRef,
     pub(crate) time: usize,
     pub(crate) loaned_tcb: Option<ThreadRef>,
+}
+
+impl ThreadTime {
+    fn time_thread(&self) -> ThreadRef {
+        self.loaned_tcb.unwrap_or(self.tcb_ref)
+    }
 }

--- a/kernel/src/space.rs
+++ b/kernel/src/space.rs
@@ -58,7 +58,7 @@ impl<T, const N: usize> Space<T, N> {
 
     #[allow(dead_code)]
     pub fn into_iter(self) -> impl Iterator<Item = T> {
-        self.items.into_iter().filter_map(|i| i)
+        self.items.into_iter().flatten()
     }
 
     #[allow(dead_code)]

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -10,7 +10,7 @@ use crate::{
     task::TaskState,
     task_ptr::{TaskPtr, TaskPtrMut},
     tcb::Tcb,
-    CapEntry, Kernel, KernelError,
+    CapEntry, DomainEntry, Kernel, KernelError,
 };
 
 #[repr(C)]
@@ -55,7 +55,7 @@ unsafe impl SysCall for SendCall {
         let next_thread = kern.scheduler.next_thread(priority);
         Ok(match next_thread {
             Some(next_thread) => CallReturn::Switch {
-                next_thread,
+                next_thread: next_thread.tcb_ref,
                 ret: abi::SyscallReturn::new()
                     .with(abi::SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
             },
@@ -152,8 +152,10 @@ unsafe impl SysCall for RecvCall {
                 next_thread: kern.scheduler.wait(self.mask, out_buf, recv_resp, false)?,
             })
         } else {
+            defmt::println!("got msg in recv");
             Ok(CallReturn::Return {
-                ret: abi::SyscallReturn::new(),
+                ret: abi::SyscallReturn::new()
+                    .with(SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
             })
         }
     }
@@ -245,11 +247,7 @@ unsafe impl SysCall for PanikCall {
             let mut cursor = domain.cursor_front_mut();
             cursor.move_prev();
             while let Some(entry) = { cursor.next() } {
-                if entry
-                    .tcb_ref
-                    .and_then(|t| kern.scheduler.tcbs.get(*t))
-                    .is_some()
-                {
+                if kern.scheduler.tcbs.get(*entry.tcb_ref).is_some() {
                     cursor.remove_current();
                 }
             }
@@ -291,8 +289,8 @@ unsafe impl SysCall for PanikCall {
         let next_thread = kern
             .scheduler
             .next_thread(0)
-            .unwrap_or_else(ThreadRef::idle);
-        let next_thread = kern.scheduler.switch_thread(next_thread, false)?;
+            .unwrap_or_else(DomainEntry::idle);
+        let next_thread = kern.scheduler.switch_thread(next_thread)?;
         Ok(CallReturn::Replace { next_thread })
     }
 }

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -4,7 +4,7 @@ use abi::{
     Cap, CapListEntry, CapRef, RecvResp, SyscallArgs, SyscallDataType, SyscallReturn,
     SyscallReturnType, ThreadRef,
 };
-use defmt::error;
+use defmt::{error, Format};
 
 use crate::{
     task::TaskState,
@@ -152,7 +152,6 @@ unsafe impl SysCall for RecvCall {
                 next_thread: kern.scheduler.wait(self.mask, out_buf, recv_resp, false)?,
             })
         } else {
-            defmt::println!("got msg in recv");
             Ok(CallReturn::Return {
                 ret: abi::SyscallReturn::new()
                     .with(SyscallReturn::SYSCALL_TYPE, SyscallReturnType::Copy),
@@ -392,6 +391,7 @@ fn get_buf<'t, const N: usize>(
     Ok(slice)
 }
 
+#[derive(Format)]
 pub enum CallReturn {
     Replace {
         next_thread: ThreadRef,

--- a/kernel/src/task.rs
+++ b/kernel/src/task.rs
@@ -100,6 +100,7 @@ impl Task {
         Ok(LoanRef(i))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn pop_loan(&mut self, loan_ref: LoanRef) -> Result<(), KernelError> {
         let loan = self
             .loans


### PR DESCRIPTION
This PR adds a new concept to K5 called "memory loans". Each task has its default memory regions in RAM and flash, but tasks will often need to access memory outside of those two regions. For instance to access the GPIO peripheral you will need access to that register block. This PR implements the ability to grant a Task access to a memory region, here called a "loan". In the future this will also be used to allow threads to safely share memory by loaning out specific memory regions.

The scheduler also got a re-work in this PR to fix a few outstanding issues. There was an edge case where if a thread had loaned out its budget to a server thread. If the server exhausted its budget during execution, it would pull the cooldown from its own task. This means that a server, which is meant to have a very large cooldown, would essentially block forever. Which would in turn block the client, and then you'd be in a deadlock. The fix was to use the client's cooldown, rather than the servers. After fixing that it became clear that there were another few edge-cases that needed to be solved. It turns out that it was possible for the same thread to be scheduled twice. This caused an issue when a thread was blocked, since the scheduler would switch into a task. The scheduler of course wouldn't set the return values for the sys call correct, which would cause an error. Fixing this nicely dove-tailed with an improvement I wanted to make to the scheduler. I replaced the existing wait queue (based on 7 linked lists), with a single priority queue. This greatly simplified lots of logic, and should be much faster overall. I plan to make a similar change to the exhausted thread queue. 