### PR TITLE
Add support for sending and receiving pages

### DIFF
--- a/abi/src/lib.rs
+++ b/abi/src/lib.rs
@@ -140,7 +140,7 @@ impl FromBits<u64> for SyscallReturnType {
     }
 }
 
-#[derive(Debug, Format)]
+#[derive(Debug, Format, Copy, Clone)]
 #[repr(u8)]
 pub enum Error {
     ReturnTypeMismatch,
@@ -233,5 +233,5 @@ pub struct RecvResp {
 #[repr(C)]
 pub enum RecvRespInner {
     Copy(usize),
-    Page(*const ()),
+    Page { addr: usize, len: usize },
 }

--- a/examples/bar/src/main.rs
+++ b/examples/bar/src/main.rs
@@ -16,12 +16,15 @@ pub fn main() -> ! {
     loop {
         a += 1;
         if a % 100000 == 0 {
-            let mut buf = [0xFFu8; 10];
-            buf[0..4].copy_from_slice(&a.to_be_bytes());
-            info!("send {:?}", buf);
-            let mut resp_buf = [0; 10];
-            let resp = endpoint.call(&mut buf, &mut resp_buf);
-            info!("resp {:?}, buf: {:?}", resp, resp_buf);
+            let mut buf = AlignedBytes([0xFFu8; 32]);
+            buf.0[0..4].copy_from_slice(&a.to_be_bytes());
+            info!("send {:?} {:x}", buf.0, buf.0.as_ptr());
+            let resp = endpoint.call_io(&mut buf.0);
+            info!("resp {:?}, buf {:?}", resp, buf.0);
         }
     }
 }
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, align(32))]
+pub struct AlignedBytes<const N: usize>(pub [u8; N]);

--- a/examples/bar/src/main.rs
+++ b/examples/bar/src/main.rs
@@ -4,7 +4,7 @@
 #![feature(asm_sym)]
 
 use defmt::{info, println};
-use userspace::CapExt;
+use userspace::{CapExt, Page};
 
 #[export_name = "main"]
 pub fn main() -> ! {
@@ -16,15 +16,11 @@ pub fn main() -> ! {
     loop {
         a += 1;
         if a % 100000 == 0 {
-            let mut buf = AlignedBytes([0xFFu8; 32]);
+            let mut buf = Page([0xFFu8; 32]);
             buf.0[0..4].copy_from_slice(&a.to_be_bytes());
             info!("send {:?} {:x}", buf.0, buf.0.as_ptr());
-            let resp = endpoint.call_io(&mut buf.0);
+            let resp = endpoint.call_io(&mut buf);
             info!("resp {:?}, buf {:?}", resp, buf.0);
         }
     }
 }
-
-#[derive(Clone, Copy, Debug)]
-#[repr(C, align(32))]
-pub struct AlignedBytes<const N: usize>(pub [u8; N]);

--- a/examples/stm32l5/src/main.rs
+++ b/examples/stm32l5/src/main.rs
@@ -8,7 +8,7 @@ use alloc_cortex_m::CortexMHeap;
 use core::{mem::MaybeUninit, panic::PanicInfo};
 use cortex_m_rt::{entry, exception};
 use defmt::{error, info};
-use kernel::RegionBuilder;
+use kernel::{RegionAttr, RegionBuilder};
 use stm32l5::stm32l562;
 
 kernel::include_task_table! {}
@@ -41,12 +41,17 @@ fn main() -> ! {
             .priority(7)
             .budget(5)
             .cooldown(usize::MAX)
-            .loan_mem(RegionBuilder::device(stm32l562::RCC::PTR).write().read())
-            .loan_mem(RegionBuilder::device(stm32l562::GPIOA::PTR).write().read())
-            .loan_mem(RegionBuilder::device(stm32l562::GPIOD::PTR).write().read())
-            .loan_mem(RegionBuilder::device(stm32l562::GPIOG::PTR).write().read())
-            .loan_mem(RegionBuilder::device(stm32l562::PWR::PTR).write().read())
-            .loan_mem(RegionBuilder::device(stm32l562::FLASH::PTR).write().read())
+            .loan_mem(
+                RegionBuilder::new(0x4000_1000..0x4202fc00, RegionAttr::Device.into())
+                    .write()
+                    .read(),
+            )
+            //.loan_mem(RegionBuilder::device(stm32l562::RCC::PTR).write().read())
+            //.loan_mem(RegionBuilder::device(stm32l562::GPIOA::PTR).write().read())
+            // .loan_mem(RegionBuilder::device(stm32l562::GPIOD::PTR).write().read())
+            // .loan_mem(RegionBuilder::device(stm32l562::GPIOG::PTR).write().read())
+            //.loan_mem(RegionBuilder::device(stm32l562::PWR::PTR).write().read())
+            //.loan_mem(RegionBuilder::device(stm32l562::FLASH::PTR).write().read())
             .listen(*b"0123456789abcdef"),
     );
 

--- a/kernel/src/arch/cortex_m.rs
+++ b/kernel/src/arch/cortex_m.rs
@@ -489,7 +489,9 @@ fn apply_region(i: usize, region: &Region, mpu: &cortex_m::peripheral::mpu::Regi
 }
 
 fn clear_region(i: usize, mpu: &cortex_m::peripheral::mpu::RegisterBlock) {
+    // Safety: writes the region num, no impact on memory safety
     unsafe { mpu.rnr.write(i as u32) };
+    // Safety: clears the particular region, no impact on memory safety
     unsafe { mpu.rlar.write(0) };
 }
 

--- a/kernel/src/arch/cortex_m.rs
+++ b/kernel/src/arch/cortex_m.rs
@@ -383,7 +383,7 @@ pub(crate) fn translate_mut_task_ptr<'a, T: ptr::Pointee + ?Sized>(
 }
 
 fn validate_addr(addr: usize, len: usize, regions: &[Region]) -> bool {
-    let end = addr + len;
+    let end = addr + len - 1;
     regions.iter().any(|r| {
         r.range.contains(&addr) && r.range.contains(&end) && r.attr.contains(RegionAttr::Read)
     })
@@ -406,6 +406,9 @@ fn apply_region_table(table: &RegionTable) {
 
     for (i, region) in table.regions.iter().enumerate() {
         apply_region(i, region, mpu);
+    }
+    for i in table.regions.len()..8 {
+        clear_region(i, mpu);
     }
 
     // Safety: this is all "safe", its just marked as unsafe because cortex_m's registers
@@ -483,6 +486,11 @@ fn apply_region(i: usize, region: &Region, mpu: &cortex_m::peripheral::mpu::Regi
         mpu.rbar.write(rbar);
         mpu.rlar.write(rlar);
     }
+}
+
+fn clear_region(i: usize, mpu: &cortex_m::peripheral::mpu::RegisterBlock) {
+    unsafe { mpu.rnr.write(i as u32) };
+    unsafe { mpu.rlar.write(0) };
 }
 
 // RTT

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -49,7 +49,7 @@ use regions::{Region, RegionTable};
 use scheduler::{Scheduler, ThreadTime};
 use space::Space;
 use task::*;
-use task_ptr::{TaskPtr, TaskPtrMut};
+use task_ptr::TaskPtr;
 
 pub(crate) const TCB_CAPACITY: usize = 16;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -176,7 +176,7 @@ impl Kernel {
                 };
                 let task = self
                     .tasks
-                    .get(dest_tcb.task.0)
+                    .get_mut(dest_tcb.task.0)
                     .ok_or(KernelError::InvalidTaskRef)?;
                 if let RecvRes::NotFound(_) = dest_tcb.recv(task, recv_req)? {
                     panic!("recv not found")

--- a/kernel/src/regions.rs
+++ b/kernel/src/regions.rs
@@ -1,12 +1,13 @@
 use core::ops::Range;
 
+use defmt::Format;
 use enumflags2::{bitflags, BitFlags};
 
 use crate::KernelError;
 
 #[derive(Clone, Default)]
 pub struct RegionTable {
-    pub regions: heapless::Vec<Region, 16>,
+    pub regions: heapless::Vec<Region, 8>,
 }
 
 #[allow(dead_code)]
@@ -23,7 +24,13 @@ impl RegionTable {
                 return Ok(());
             }
             let mut old_end = None;
+
             if self.regions[i].range.contains(&region.range.start) {
+                if self.regions[i].range.contains(&region.range.end)
+                    && self.regions[i].attr.contains(region.attr)
+                {
+                    return Ok(());
+                }
                 inserted_at = Some(i);
                 old_end = Some(self.regions[i].range.end);
                 self.regions[i].range.end = region.range.start; // TODO: Handle case where region.start == new_region.start

--- a/kernel/src/regions.rs
+++ b/kernel/src/regions.rs
@@ -1,6 +1,4 @@
 use core::ops::Range;
-
-use defmt::Format;
 use enumflags2::{bitflags, BitFlags};
 
 use crate::KernelError;

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -361,7 +361,7 @@ unsafe impl SysCall for ConnectCall {
     }
 }
 
-fn get_msg<'t>(
+fn get_msg(
     kern: &mut Kernel,
     arg_type: SyscallDataType,
     addr: usize,

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -151,7 +151,7 @@ unsafe impl SysCall for RecvCall {
         let tcb = kern.scheduler.current_thread_mut()?;
         let task = kern
             .tasks
-            .get(tcb.task.0)
+            .get_mut(tcb.task.0)
             .ok_or(KernelError::InvalidTaskRef)?;
         if let RecvRes::NotFound(req) = tcb.recv(task, recv_req)? {
             Ok(CallReturn::Replace {

--- a/kernel/src/task.rs
+++ b/kernel/src/task.rs
@@ -1,7 +1,6 @@
-use crate::regions::{Region, RegionTable};
-use crate::space::Space;
+use crate::arch;
+use crate::regions::RegionTable;
 use crate::task_ptr::{TaskPtr, TaskPtrMut};
-use crate::{arch, KernelError};
 use core::ops::Range;
 use heapless::Vec;
 

--- a/kernel/src/task_ptr.rs
+++ b/kernel/src/task_ptr.rs
@@ -1,4 +1,4 @@
-use core::ptr::Pointee;
+use core::{mem, ptr::Pointee};
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -41,11 +41,15 @@ impl<'a, T: Pointee + ?Sized> TaskPtrMut<'a, T> {
         self.ptr
     }
 
-    #[allow(dead_code)]
     #[inline]
     pub(crate) fn addr(&self) -> usize {
         let (ptr, _) = (self.ptr as *const T).to_raw_parts();
         ptr.addr()
+    }
+
+    #[inline]
+    pub(crate) fn size(&self) -> usize {
+        mem::size_of_val(self.ptr)
     }
 }
 

--- a/kernel/src/task_ptr.rs
+++ b/kernel/src/task_ptr.rs
@@ -1,4 +1,4 @@
-use core::{mem, ptr::Pointee};
+use core::{mem, ops::Range, ptr::Pointee};
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -50,6 +50,11 @@ impl<'a, T: Pointee + ?Sized> TaskPtrMut<'a, T> {
     #[inline]
     pub(crate) fn size(&self) -> usize {
         mem::size_of_val(self.ptr)
+    }
+
+    pub(crate) fn range(&self) -> Range<usize> {
+        let addr = self.addr();
+        addr..addr + self.size()
     }
 }
 

--- a/kernel/src/task_ptr.rs
+++ b/kernel/src/task_ptr.rs
@@ -1,4 +1,4 @@
-use core::{mem, ops::Range, ptr::Pointee};
+use core::ptr::Pointee;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -39,22 +39,6 @@ impl<'a, T: Pointee + ?Sized> TaskPtrMut<'a, T> {
 
     pub(crate) unsafe fn ptr(self) -> &'a mut T {
         self.ptr
-    }
-
-    #[inline]
-    pub(crate) fn addr(&self) -> usize {
-        let (ptr, _) = (self.ptr as *const T).to_raw_parts();
-        ptr.addr()
-    }
-
-    #[inline]
-    pub(crate) fn size(&self) -> usize {
-        mem::size_of_val(self.ptr)
-    }
-
-    pub(crate) fn range(&self) -> Range<usize> {
-        let addr = self.addr();
-        addr..addr + self.size()
     }
 }
 

--- a/userspace/src/cortex_m.rs
+++ b/userspace/src/cortex_m.rs
@@ -1,5 +1,5 @@
 use abi::{
-    CapListEntry, CapRef, Error, RecvResp, SyscallArgs, SyscallDataType, SyscallFn, SyscallIndex,
+    CapListEntry, CapRef, Error, SyscallArgs, SyscallDataType, SyscallFn, SyscallIndex,
     SyscallReturn, SyscallReturnType,
 };
 use core::fmt::Write;
@@ -9,6 +9,7 @@ use core::{
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
 };
+use defmt::Format;
 
 #[doc(hidden)]
 #[no_mangle]
@@ -116,14 +117,14 @@ fn call_innner<T: ?Sized>(
     capability: CapRef,
     r: &mut T,
     out: Option<&mut T>,
-) -> Result<RecvResp, Error> {
+) -> Result<abi::RecvResp, Error> {
     let size = core::mem::size_of_val(r);
     let (ptr, _) = (r as *mut T).to_raw_parts();
     let addr = ptr.addr();
     let index = SyscallIndex::new()
         .with(SyscallIndex::SYSCALL_ARG_TYPE, ty)
         .with(SyscallIndex::SYSCALL_FN, SyscallFn::Call);
-    let mut resp: MaybeUninit<RecvResp> = MaybeUninit::uninit();
+    let mut resp: MaybeUninit<abi::RecvResp> = MaybeUninit::uninit();
     let (out_size, out_addr) = if let Some(out) = out {
         let (ptr, _) = (out as *mut T).to_raw_parts();
         (core::mem::size_of_val(out), ptr.addr())
@@ -174,16 +175,16 @@ pub(crate) fn log(data: &[u8]) -> Result<(), Error> {
 
 pub trait CapExt {
     /// Sends a request to the capability and waits for a reply
-    fn call<T: ?Sized>(&self, request: &mut T, out_buf: &mut T) -> Result<RecvResp, Error>;
+    fn call<T: ?Sized>(&self, request: &mut T, out_buf: &mut T) -> Result<RecvResp<T>, Error>;
 
     /// Sends a request to the capability loaning the data in the io buf and waits for a reply
-    fn call_io<T: ?Sized>(&self, io: &mut T) -> Result<(), Error>;
+    fn call_io<'a, A: Aligned + 'a>(&self, io: &'a mut A) -> Result<(), Error>;
 
     /// Sends a request to the capability, and returns ASAP
     fn send<T: ?Sized>(&self, request: &mut T) -> Result<(), Error>;
 
     /// Sends a request to the capability, and returns ASAP
-    fn send_page<T: ?Sized>(&self, request: &'static mut T) -> Result<(), Error>;
+    fn send_page<A: Aligned + 'static>(&self, request: A) -> Result<(), Error>;
 
     /// Listens to the port on the specified capability
     fn listen(&self) -> Result<(), Error>;
@@ -192,11 +193,19 @@ pub trait CapExt {
 }
 
 impl CapExt for CapRef {
-    fn call<T: ?Sized>(&self, r: &mut T, out_buf: &mut T) -> Result<RecvResp, Error> {
-        call_innner(SyscallDataType::Copy, *self, r, Some(out_buf))
+    fn call<T: ?Sized>(&self, r: &mut T, out_buf: &mut T) -> Result<RecvResp<T>, Error> {
+        let resp = call_innner(SyscallDataType::Copy, *self, r, Some(out_buf))?;
+        if let abi::RecvRespInner::Copy(len) = resp.inner {
+            Ok(RecvResp {
+                cap: resp.cap,
+                body: RecvRespBody::Copy(len),
+            })
+        } else {
+            Err(Error::ReturnTypeMismatch)
+        }
     }
 
-    fn call_io<T: ?Sized>(&self, io: &mut T) -> Result<(), Error> {
+    fn call_io<'a, A: Aligned + 'a>(&self, io: &'a mut A) -> Result<(), Error> {
         match call_innner(SyscallDataType::Page, *self, io, None)?.inner {
             abi::RecvRespInner::Copy(_) => {
                 return Err(Error::ReturnTypeMismatch);
@@ -204,8 +213,8 @@ impl CapExt for CapRef {
             abi::RecvRespInner::Page { addr, len } => {
                 // Since we are taking a mutable borrow over just the course of the syscall, we must guarentee
                 // that we are getting back the same memory
-                let (ptr, _) = (io as *mut T).to_raw_parts();
-                if addr != ptr.addr() || mem::size_of_val(io) != len {
+                let (ptr, _) = (io.deref_mut() as *mut A::Target).to_raw_parts();
+                if addr != ptr.addr() || mem::size_of_val(io.deref_mut()) != len {
                     defmt::error!("addr mismatch");
                     return Err(Error::ReturnTypeMismatch);
                 }
@@ -218,8 +227,8 @@ impl CapExt for CapRef {
         send_inner(SyscallDataType::Copy, *self, r)
     }
 
-    fn send_page<T: ?Sized>(&self, r: &'static mut T) -> Result<(), Error> {
-        send_inner(SyscallDataType::Page, *self, r)
+    fn send_page<A: Aligned + 'static>(&self, mut request: A) -> Result<(), Error> {
+        send_inner::<A::Target>(SyscallDataType::Page, *self, request.deref_mut())
     }
 
     fn listen(&self) -> Result<(), Error> {
@@ -261,13 +270,13 @@ impl CapExt for CapRef {
 ///
 /// This function will block until until another thread sends a request to
 /// the current thread
-pub fn recv<T: ?Sized>(mask: u32, r: &mut T) -> Result<abi::RecvResp, Error> {
+pub fn recv<T: ?Sized, R: Sized>(mask: u32, r: &mut T) -> Result<RecvResp<R>, Error> {
     let size = core::mem::size_of_val(r);
     let (ptr, _) = (r as *mut T).to_raw_parts();
     let index = SyscallIndex::new()
         .with(SyscallIndex::SYSCALL_ARG_TYPE, SyscallDataType::Copy)
         .with(SyscallIndex::SYSCALL_FN, SyscallFn::Recv);
-    let mut resp: MaybeUninit<RecvResp> = MaybeUninit::uninit();
+    let mut resp: MaybeUninit<abi::RecvResp> = MaybeUninit::uninit();
     let mut args = SyscallArgs {
         arg1: ptr.addr(),
         arg2: size,
@@ -281,30 +290,34 @@ pub fn recv<T: ?Sized>(mask: u32, r: &mut T) -> Result<abi::RecvResp, Error> {
             let code = res.get(SyscallReturn::SYSCALL_LEN);
             Err(abi::Error::from(code as u8))
         }
-        _ => Ok(unsafe { resp.assume_init() }),
+        _ => {
+            let resp = unsafe { resp.assume_init() };
+            Ok(RecvResp {
+                cap: resp.cap,
+                body: match resp.inner {
+                    abi::RecvRespInner::Copy(len) => RecvRespBody::Copy(len),
+                    abi::RecvRespInner::Page { addr, len } => {
+                        if len != mem::size_of::<R>() {
+                            return Err(Error::ReturnTypeMismatch);
+                        }
+                        RecvRespBody::Page(PageRefMut(unsafe { core::mem::transmute(addr) }))
+                    }
+                },
+            })
+        }
     }
 }
 
-pub struct LoanedPage<T: ?Sized> {
-    ptr: *mut T,
+#[derive(Format)]
+pub struct RecvResp<T: ?Sized + 'static> {
+    pub cap: Option<CapRef>,
+    pub body: RecvRespBody<T>,
 }
 
-impl<T> Deref for LoanedPage<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        // Safety: the kernel guarentees that no other thread will touch this memory,
-        // so we can safely borrow it
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<T> DerefMut for LoanedPage<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        // Safety: the kernel guarentees that no other thread will touch this memory,
-        // so we can safely borrow it
-        unsafe { &mut *self.ptr }
-    }
+#[derive(Format)]
+pub enum RecvRespBody<T: ?Sized + 'static> {
+    Copy(usize),
+    Page(PageRefMut<'static, T>),
 }
 
 /// Retrieves the tasks current capabilities
@@ -414,3 +427,42 @@ impl Write for LenWrite {
         Ok(())
     }
 }
+
+#[derive(defmt::Format)]
+#[repr(C, align(32))]
+pub struct Page<T: ?Sized>(pub T);
+
+impl<T> Deref for Page<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Page<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Format)]
+pub struct PageRefMut<'a, T: ?Sized + 'a>(&'a mut T);
+impl<T> Deref for PageRefMut<'static, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for PageRefMut<'static, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub trait Aligned: Deref + DerefMut {}
+
+impl<T> Aligned for Page<T> {}
+impl<T> Aligned for PageRefMut<'static, T> {}


### PR DESCRIPTION
This PR adds support for sending and receiving pages of memory. In essence, when sending a large buffer around you'd rather not waste 2x copies into the kernel than into receiving memory space. This allows you to simply send a pointer of your own memory, and then have the MPU be modified to give the receiving task that memory.

The ideal use case is for a shared request response buffer, either in the format of an `enum` like `enum ReqReply { Request(Req), Reply(Reply) }`, or in a struct with both fields. This allows the same memory region to be returned on reply to a call. 