### PR TITLE
Allow more flexible memory layout in k5 cli

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -12,11 +12,10 @@ pub struct TaskList {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Task {
     pub name: String,
-    pub entrypoint: u32,
-    pub stack_space: Range<u32>,
-    pub init_stack_size: u32,
-    pub flash_region: Range<u32>,
-    pub ram_region: Range<u32>,
+    pub entrypoint: usize,
+    pub stack_space: Range<usize>,
+    pub init_stack_size: usize,
+    pub regions: Vec<Range<usize>>,
 }
 
 impl TaskList {
@@ -32,15 +31,9 @@ name: {:?},
 entrypoint: {},
 stack_space: {:?},
 init_stack_size: {},
-flash_region: {:?},
-ram_region: {:?},
+regions: &{:?}
 }},",
-                task.name,
-                task.entrypoint,
-                task.stack_space,
-                task.init_stack_size,
-                task.flash_region,
-                task.ram_region
+                task.name, task.entrypoint, task.stack_space, task.init_stack_size, task.regions,
             );
         }
         code += "];\n";

--- a/examples/stm32l5/app.toml
+++ b/examples/stm32l5/app.toml
@@ -1,17 +1,19 @@
-flash = { address = 0x08000000, size = 0x80000 }
-ram  =  { address = 0x20000000, size = 0x40000 }
 stack_space_size = 0x2000
 stack_size = 0x1000
+platform = "ArmV8m"
+
+[regions]
+flash = { address = 0x08000000, size = 0x80000 }
+ram = { address = 0x20000000, size = 0x40000, role = "stack" }
 
 [probe]
 chip = "STM32L562QEIxQ"
 
 [kernel]
 crate_path = "./"
-ram_size   = 0x20000
 stack_size = 0x00004
-#flash_size = 0x9000 # min size
-flash_size = 0x20000
+sizes.ram = 0x20000
+sizes.flash = 0x20000
 
 [[tasks]]
 name = "idle"

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -385,24 +385,20 @@ pub struct TaskDesc {
     pub entrypoint: usize,
     pub stack_space: Range<usize>,
     pub init_stack_size: usize,
-    pub flash_region: Range<usize>,
-    pub ram_region: Range<usize>,
+    pub regions: &'static [Range<usize>],
 }
 
 impl TaskDesc {
     fn region_table(&self) -> RegionTable {
         RegionTable {
-            regions: Vec::from_slice(&[
-                Region {
-                    range: self.flash_region.clone(),
+            regions: self
+                .regions
+                .iter()
+                .map(|range| Region {
+                    range: range.clone(),
                     attr: RegionAttr::Exec | RegionAttr::Write | RegionAttr::Read,
-                },
-                Region {
-                    range: self.ram_region.clone(),
-                    attr: RegionAttr::Exec | RegionAttr::Write | RegionAttr::Read,
-                },
-            ])
-            .unwrap(),
+                })
+                .collect(),
         }
     }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -28,3 +28,52 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+body {
+  font-family: Helvetica Neue;
+}
+
+.menu__link--active {
+  background-color: var(--ifm-color-primary) !important;
+  color: #fff;
+}
+
+.menu {
+  padding-top: -0.5rem;
+  padding-bottom: -0.5rem;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.menu__link {
+  border-radius: 0 !important;
+  padding-top: .6em;
+  padding-bottom: .6em;
+}
+
+.menu__link--active:hover {
+  color: #fff !important;
+}
+.menu__list-item-collapsible :hover {
+  color: var(--ifm-color-primary) !important;
+}
+
+
+.menu__list-item-collapsible .menu__link:hover, .menu__list-item-collapsible .menu__link--active {
+  color: var(--ifm-color-primary);
+}
+
+.breadcrumbs__link {
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.navbar {
+  box-shadow: none !important;
+  border-bottom: 2px solid var(--ifm-color-primary);
+}
+
+
+.card {
+  box-shadow: none !important;
+}


### PR DESCRIPTION
This PR makes K5's memory layout more flexible. The build tool assumed there was always a region called RAM and FLASH, but that is pretty much only the case on on Cortex M microcontrollers. And even then it's not guaranteed. So this PR lets you define your own region and linker scripts for the kernel